### PR TITLE
Fix deadlock with `Reset()` and `CheckResetByPublishers()`

### DIFF
--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -1083,7 +1083,7 @@ void Tracking::CheckResetByPublishers()
     {
         {
             boost::mutex::scoped_lock lock(mMutexReset);
-            if(!mbReseting)
+            if(!bReseting || !mbReseting)
             {
                 mbPublisherStopped=false;
                 break;


### PR DESCRIPTION
Here we can get situation when `CheckResetByPublishers` starts when `mbReseting` is `false`. When we go inside `while` cycle, `mbReseting` can change to `true` in another thread in `Reset()` method.