### PR TITLE
DBoW: ScoringObject.h fix undefined behavior upon dtor

### DIFF
--- a/Thirdparty/DBoW2/DBoW2/ScoringObject.h
+++ b/Thirdparty/DBoW2/DBoW2/ScoringObject.h
@@ -39,7 +39,8 @@ public:
 	static const double LOG_EPS; 
   // If you change the type of WordValue, make sure you change also the
 	// epsilon value (this is needed by the KL method)
-	
+
+  virtual ~GeneralScoring() {} //!< Required for virtual base classes	
 };
 
 /** 


### PR DESCRIPTION
Fixes:

ORB_SLAM/Thirdparty/DBoW2/DBoW2/TemplatedVocabulary.h:529:3: warning: deleting object of abstract class type ‘DBoW2::GeneralScoring’ which has non-virtual destructor will cause undefined behaviour [-Wdelete-non-virtual-dtor]

